### PR TITLE
Add sort list by due date function

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,13 +142,11 @@ def sort_list_by_due_date(id_list: str, reverse=False) -> None:
             id_due_date_dict[card['id']] = datetime.datetime.strptime(card['due'][0:10], '%Y-%m-%d')
         else:
             id_due_date_dict[card['id']] = None
-    sorted_dict = sorted(id_due_date_dict.items(), key=lambda d: (d[1] is None, d[1]), reverse=reverse)
+    id_due_date_sorted_dict = sorted(id_due_date_dict.items(), key=lambda d: (d[1] is None, d[1]), reverse=reverse)
 
     position = first_position
-    positions = []
-    for item in sorted_dict:
-        response = make_trello_request(f'cards/{item[0]}', params={'pos': f'{position}'}, method='PUT')
-        positions.append(json.loads(response.text)['pos'])
+    for id_due_date in id_due_date_sorted_dict:
+        response = make_trello_request(f'cards/{id_due_date[0]}', params={'pos': f'{position}'}, method='PUT')
         position = position + first_position
 
 


### PR DESCRIPTION
Byl tam trochu poblem, jelikoz ten backend trella ma nejaky algoritmus na pridelovani pozice a muze zmenit jeji hodnotu samovolne. Kdyz jsem prideloval  hodnoty 0 az N, tak jsem musel volat funkci 2x, aby byla spravne serazena. S timhle zpusobem pridelovani to funguje, ale nevim jestli to bude fugovat u delsich listu. Prosim otestuj u sebe.

Udelal jsem to tak ze karticky bez due_date budou vzdy nakonci. 